### PR TITLE
高さがオーバーフロする不具合を解決

### DIFF
--- a/widgetbook/lib/daily_check_list.dart
+++ b/widgetbook/lib/daily_check_list.dart
@@ -7,33 +7,48 @@ class DailyCheckList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const calendarTextStyle = TextStyle(fontSize: 16, color: Colors.white);
     return Card(
       color: const Color.fromRGBO(77, 182, 172, 1),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 50, horizontal: 10),
-        child: GridView.builder(
-          shrinkWrap: true, // 高さをコンテンツに合わせる
-          physics: const NeverScrollableScrollPhysics(),
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 7,
-          ),
-          itemCount: isExercisedList.length,
-          itemBuilder: (context, index) {
-            int day = index + 1;
-            bool isDone = isExercisedList[index];
+        child: Expanded(
+          child: GridView.builder(
+            shrinkWrap: true, // 高さをコンテンツに合わせる
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 7,
+            ),
+            itemCount: isExercisedList.length,
+            itemBuilder: (context, index) {
+              int day = index + 1;
+              bool isDone = isExercisedList[index];
 
-            return GridTile(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text('$day日', style: calendarTextStyle),
-                  Text(isDone ? '済' : '', style: calendarTextStyle),
-                ],
-              ),
-            );
-          },
+              return _DailyCheckListCell(day: day, isDone: isDone);
+            },
+          ),
         ),
+      ),
+    );
+  }
+}
+
+class _DailyCheckListCell extends StatelessWidget {
+  final int day;
+  final bool isDone;
+
+  const _DailyCheckListCell({required this.day, required this.isDone});
+
+  @override
+  Widget build(BuildContext context) {
+    const calendarTextStyle = TextStyle(fontSize: 16, color: Colors.white);
+
+    return GridTile(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Flexible(child: Text('$day日', style: calendarTextStyle)),
+          Flexible(child: Text(isDone ? '済' : '', style: calendarTextStyle)),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## やったこと
- iosでビルドするとBeforeのように、GridTileに対してテキストの高さがオーバーフローしている。
- TextをFlexibleでラップすることによって解決するようにした。

| Before | After |
|--------|--------|
| <img src=https://github.com/user-attachments/assets/b10d9bdc-6e3c-4733-b640-98521a446ec0  width=50%> | <img src=https://github.com/user-attachments/assets/dce0ebdb-c03b-451e-b4b7-a9c7547d7bc5  width=50%> |

